### PR TITLE
Explicitly specify cpus per task on worker script.

### DIFF
--- a/spark-start
+++ b/spark-start
@@ -232,7 +232,7 @@ sed -i "s/SPARK_WORKER_CORES=${SPARK_WORKER_CORES}/SPARK_WORKER_CORES=${SPARK_WO
     "${SCRATCH}/sparkworker.sh"
 
 # Start the worker nodes.
-srun --label --export=ALL --wait=0 "${SCRATCH}/sparkworker.sh" &
+srun --label --export=ALL --wait=0 --cpus-per-task=${SLURM_CPUS_PER_TASK} "${SCRATCH}/sparkworker.sh" &
 WORKERS_PID=$!
 echo "WORKERS_PID=${WORKERS_PID}"
 echo "export WORKERS_PID=${WORKERS_PID}" >> ${SPARK_CONF_DIR}/spark-env.sh


### PR DESCRIPTION
Changes to Slurm resulted in srun no longer recognizing SLURM_CPUS_PER_TASK env var. This was causing the Spark workers launched by srun to run with a limit of 1 cpu per worker process. Spark jobs were taking a very long time to run.

This commit fixes the issue by explicity specifying the number of cpus per task to be equal to the env var SLURM_CPUS_PER_TASK.