### PR TITLE
Fix error from slow master process start.

### DIFF
--- a/spark-start
+++ b/spark-start
@@ -199,9 +199,9 @@ if [ $? -ne 0 ]; then
     echo "Output of the start script was: ${START_OUTPUT}"
     exit 1
 fi
-echo "Spark master started."
+echo "Spark master start script finished."
 echo "Output of the start script was: ${START_OUTPUT}"
-SPARK_MASTER_LOG=$(echo ${START_OUTPUT} | sed 's/^.*logging to //')
+SPARK_MASTER_LOG=$(ls -1 ${SPARK_LOG_DIR}/*master*.out | head -n 1)
 echo "SPARK_MASTER_LOG: ${SPARK_MASTER_LOG}"
 
 # Wait here until master starts and logs its URL. There is sometimes a
@@ -210,8 +210,19 @@ LOOP_COUNT=0
 while ! grep -q "started at http://" ${SPARK_MASTER_LOG}; do
     echo -n ".."
     sleep 2
-    if [ ${LOOP_COUNT} -gt 30 ]; then
-        echo "Error: Spark Master did not start."
+    if [ ${LOOP_COUNT} -gt 300 ]; then
+        echo "Error: Spark Master did not start. Web UI address not found in master log."
+        exit 1
+    fi
+    LOOP_COUNT=$(( LOOP_COUNT + 1 ))
+done
+
+LOOP_COUNT=0
+while ! grep -q "spark://" ${SPARK_MASTER_LOG}; do
+    echo -n ".."
+    sleep 2
+    if [ ${LOOP_COUNT} -gt 300 ]; then
+        echo "Error: Spark Master did not start. Spark URL not found in master log."
         exit 1
     fi
     LOOP_COUNT=$(( LOOP_COUNT + 1 ))


### PR DESCRIPTION
Fix an intermittent error that occurs when the master process is slow to start.

Occassionally, the master process does not start within a timing threshold specified in the `${SPARK_HOME}/sbin/spark-daemon.sh` script. Under those conditions, the output of `${SPARK_HOME}/sbin/start-master.sh` contains extra text that is not properly parsed by `spark-start` when locating the master process log file.

Instead of parsing the output of the `start-master.sh` script to locate the master process log file, this commit will ignore the output of the script, and list the contents of the spark logging directory to locate the master process log file.

Additionally, the intermittent error seems to occur when the system is experiencing slow response time generally. In order to compensate for the slow response time, the 1 minute timer that waits for the master process to write it's web UI URL and spark URL to the log file is increased to 10 minutes and 10 minutes.